### PR TITLE
PR1: todoアプリ追加の実装

### DIFF
--- a/src/ejs/components/_body.ejs
+++ b/src/ejs/components/_body.ejs
@@ -1,0 +1,11 @@
+<h1>ToDo</h1>
+<section class="add">
+  <form id="js-form">
+    <input id="js-form-input" class="add_textArea" type="text" placeholder="ToDo" />
+    <button class="add_button">追加</button>
+  </form>
+  <div id="js-todo-list" class="list"></div>
+  <div class="count">
+    <span id="js-todo-count">ToDoアイテム数:</span>
+  </div>
+</section>

--- a/src/ejs/components/_heading.ejs
+++ b/src/ejs/components/_heading.ejs
@@ -1,1 +1,0 @@
-<h1 class="heading">sample page</h1>

--- a/src/ejs/index.ejs
+++ b/src/ejs/index.ejs
@@ -3,8 +3,7 @@
   <%- include('./modules/_head') %>
   <body>
     <main>
-      <%- include('./components/_heading') %>
-      <p>this is sample.</p>
+      <%- include('./components/_body') %>
     </main>
   </body>
 </html>

--- a/src/ejs/modules/_head.ejs
+++ b/src/ejs/modules/_head.ejs
@@ -11,7 +11,7 @@
   <meta property="og:site_name" content="title" />
   <meta property="og:locale" content="ja" />
   <meta property="twitter:card" content="summary_large_image" />
-  <title>title</title>
+  <title>ToDo app</title>
   <link rel="icon" href="./assets/images/favicon.ico" />
   <link rel="canonical" href="https://example.com/" />
   <link rel="stylesheet" href="./assets/css/common.css" />

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,3 @@
-import fn from './modules/sample';
+import todo from './modules/todo';
 
-fn('sample');
+todo();

--- a/src/js/modules/sample.js
+++ b/src/js/modules/sample.js
@@ -1,5 +1,0 @@
-const fn = (str) => {
-  console.log(str);
-}
-
-export default fn;

--- a/src/js/modules/todo.js
+++ b/src/js/modules/todo.js
@@ -1,0 +1,61 @@
+/**
+ * ToDoアプリの実装
+ */
+
+const todo = () => {
+  /**
+  * @type {Element} フォーム要素の取得
+  */
+  const formElement = document.querySelector("#js-form");
+
+  /**
+  * @type {Element} 入力欄要素の取得
+  */
+  const inputElement = document.querySelector("#js-form-input");
+
+  /**
+  * @type {Element} Todoリストのコンテナ要素の取得
+  */
+  const containerElement = document.querySelector("#js-todo-list");
+
+  /**
+  * @type {Element} Todoアイテム数の表示要素を取得
+  */
+  const todoItemCountElement = document.querySelector("#js-todo-count");
+
+  /**
+  * @type {Element} Todoリストをまとめる、ul要素を格納する
+  */
+  const todoListElement = document.createElement('ul');
+
+  /**
+  * @type {number} 現在のアイテム数
+  */
+  let todoItemCount = 0;
+
+  formElement.addEventListener("submit", (e) => {
+
+    // 本来のsubmitイベントの動作を止める
+    e.preventDefault();
+    
+    // 追加するTodoアイテムのli要素を作成
+    const todoItemElement = document.createElement('li');
+    todoItemElement.textContent = inputElement.value;
+
+    // TodoアイテムをtodoListElementに追加
+    todoListElement.appendChild(todoItemElement);
+
+    // Todoリストのコンテナ要素の中身をTodoリストをまとめるlist要素で上書き
+    containerElement.innerHTML = '';
+    containerElement.appendChild(todoListElement);
+
+    // Todoアイテム数の更新
+    todoItemCount += 1;
+    todoItemCountElement.textContent = `ToDoアイテム数: ${todoItemCount}`;
+
+    // 入力欄をリセット
+    inputElement.value = "";
+  });
+}
+
+export default todo;


### PR DESCRIPTION
## 対応内容
- JS PrimerのTodoアプリの制作：https://jsprimer.net/use-case/todoapp/
- [エントリーポイント]〜[アイテムの追加を実装する]まで

### ブラウザチェック

- [✅] Chrome
- [✅] Safari
- [✅] Edge
- [✅] Firefox

## 申し送り
- 関数を使用する実装にしています（todo関数）
- 新しいHTML要素を作成するために（動的に生成するために）`document.createElement()`を使用し、`appendChild`を使って要素をDOMに追加する方法で実装しました
- 変数（`todoItemCount`や`todoListElement`）は関数の外で宣言する形で記述しています